### PR TITLE
feat: lighten dashboard collaboration panels for readability

### DIFF
--- a/frontend/src/app/dashboard/components/ai-spotlight.tsx
+++ b/frontend/src/app/dashboard/components/ai-spotlight.tsx
@@ -9,9 +9,9 @@ interface AiSpotlightProps {
 }
 
 const impactBadge = {
-  positive: 'bg-emerald-500/15 text-emerald-300',
-  negative: 'bg-rose-500/15 text-rose-300',
-  neutral: 'bg-cyan-500/15 text-cyan-300',
+  positive: 'bg-emerald-100 text-emerald-700',
+  negative: 'bg-rose-100 text-rose-700',
+  neutral: 'bg-cyan-100 text-cyan-700',
 } as const;
 
 /**
@@ -20,22 +20,25 @@ const impactBadge = {
 export function AiSpotlight({ insights }: AiSpotlightProps) {
   return (
     <motion.section
-      className="glass-panel relative flex flex-col overflow-hidden"
+      className="light-panel relative flex flex-col overflow-hidden"
       initial={{ opacity: 0, y: 24 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, ease: 'easeOut' }}
     >
-      <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/5 via-transparent to-cyan-500/5" aria-hidden />
-      <div className="relative flex flex-col gap-6 p-8">
+      <div
+        className="absolute inset-0 bg-gradient-to-br from-emerald-100/60 via-transparent to-cyan-100/60"
+        aria-hidden
+      />
+      <div className="relative flex flex-col gap-6 p-8 text-slate-900">
         <header className="flex items-start justify-between">
           <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-white/60">AI spotlight</p>
-            <h2 className="mt-2 flex items-center gap-2 text-lg font-semibold text-white">
-              <Sparkles className="h-5 w-5 text-emerald-300" /> Predictive insights
+            <p className="text-xs uppercase tracking-[0.4em] text-slate-500">AI spotlight</p>
+            <h2 className="mt-2 flex items-center gap-2 text-lg font-semibold text-slate-900">
+              <Sparkles className="h-5 w-5 text-emerald-500" /> Predictive insights
             </h2>
           </div>
-          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-white/70">
-            <Bot className="h-4 w-4 text-cyan-300" />
+          <span className="inline-flex items-center gap-2 rounded-full border border-cyan-200 bg-cyan-50 px-3 py-1 text-xs text-cyan-700">
+            <Bot className="h-4 w-4 text-cyan-500" />
             Copilot live
           </span>
         </header>
@@ -43,20 +46,22 @@ export function AiSpotlight({ insights }: AiSpotlightProps) {
           {insights.map((insight) => (
             <motion.li
               key={insight.id}
-              className="group rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:border-emerald-400/40 hover:shadow-[0_20px_40px_rgba(0,255,136,0.15)]"
+              className="group rounded-2xl border border-slate-200 bg-white/70 p-5 transition hover:border-emerald-300 hover:shadow-[0_16px_30px_rgba(16,185,129,0.15)]"
               initial={{ opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.45, ease: 'easeOut' }}
             >
               <div className="flex flex-wrap items-start justify-between gap-3">
-                <h3 className="text-sm font-semibold text-white/90">{insight.title}</h3>
-                <span className={`rounded-full px-3 py-1 text-xs ${impactBadge[insight.impact]}`}>
+                <h3 className="text-sm font-semibold text-slate-900">{insight.title}</h3>
+                <span
+                  className={`rounded-full px-3 py-1 text-xs shadow-sm ${impactBadge[insight.impact]}`}
+                >
                   Confidence {(insight.confidence * 100).toFixed(0)}%
                 </span>
               </div>
-              <p className="mt-3 text-sm text-white/70">{insight.summary}</p>
-              <p className="mt-4 text-xs uppercase tracking-[0.35em] text-emerald-200/70">Next action</p>
-              <p className="mt-1 text-sm text-white">{insight.action}</p>
+              <p className="mt-3 text-sm text-slate-600">{insight.summary}</p>
+              <p className="mt-4 text-xs uppercase tracking-[0.35em] text-emerald-600/80">Next action</p>
+              <p className="mt-1 text-sm text-slate-900">{insight.action}</p>
             </motion.li>
           ))}
         </ul>

--- a/frontend/src/app/dashboard/components/collaboration-panel.tsx
+++ b/frontend/src/app/dashboard/components/collaboration-panel.tsx
@@ -9,9 +9,9 @@ interface CollaborationPanelProps {
 }
 
 const statusColor = {
-  online: 'text-emerald-300',
-  offline: 'text-white/40',
-  presenting: 'text-cyan-300',
+  online: 'text-emerald-600',
+  offline: 'text-slate-400',
+  presenting: 'text-cyan-600',
 } as const;
 
 /**
@@ -20,22 +20,25 @@ const statusColor = {
 export function CollaborationPanel({ users }: CollaborationPanelProps) {
   return (
     <motion.section
-      className="glass-panel relative flex flex-col overflow-hidden"
+      className="light-panel relative flex flex-col overflow-hidden"
       initial={{ opacity: 0, y: 24 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, ease: 'easeOut' }}
     >
-      <div className="absolute inset-0 bg-gradient-to-br from-purple-500/5 via-transparent to-emerald-500/5" aria-hidden />
-      <div className="relative flex flex-col gap-6 p-8">
+      <div
+        className="absolute inset-0 bg-gradient-to-br from-emerald-100/70 via-transparent to-cyan-100/60"
+        aria-hidden
+      />
+      <div className="relative flex flex-col gap-6 p-8 text-slate-900">
         <header className="flex items-start justify-between">
           <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-white/60">Collaboration</p>
-            <h2 className="mt-2 flex items-center gap-2 text-lg font-semibold text-white">
-              <Users className="h-5 w-5 text-cyan-300" /> Team presence
+            <p className="text-xs uppercase tracking-[0.4em] text-slate-500">Collaboration</p>
+            <h2 className="mt-2 flex items-center gap-2 text-lg font-semibold text-slate-900">
+              <Users className="h-5 w-5 text-cyan-600" /> Team presence
             </h2>
           </div>
-          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-white/70">
-            <Activity className="h-4 w-4 text-emerald-300" />
+          <span className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs text-emerald-700">
+            <Activity className="h-4 w-4 text-emerald-500" />
             Live
           </span>
         </header>
@@ -43,26 +46,30 @@ export function CollaborationPanel({ users }: CollaborationPanelProps) {
           {users.map((user) => (
             <motion.li
               key={user.id}
-              className="flex items-center gap-4 rounded-2xl border border-white/10 bg-white/5 p-4"
+              className="flex items-center gap-4 rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm"
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.45, ease: 'easeOut' }}
             >
-              <span className="relative inline-flex h-12 w-12 items-center justify-center rounded-full bg-white/10 text-lg font-semibold text-white">
+              <span className="relative inline-flex h-12 w-12 items-center justify-center rounded-full bg-slate-900/5 text-lg font-semibold text-slate-900">
                 {user.name
                   .split(' ')
                   .map((part) => part[0])
                   .join('')}
-                <span className={`absolute -right-1 -top-1 h-3.5 w-3.5 rounded-full border border-slate-900 ${user.status === 'offline' ? 'bg-slate-600' : 'bg-emerald-400'}`} />
+                <span
+                  className={`absolute -right-1 -top-1 h-3.5 w-3.5 rounded-full border border-white ${
+                    user.status === 'offline' ? 'bg-slate-300' : 'bg-emerald-400'
+                  }`}
+                />
               </span>
               <div className="flex flex-1 flex-col gap-1">
                 <div className="flex flex-wrap items-center gap-2">
-                  <p className="text-sm font-semibold text-white">{user.name}</p>
-                  <span className="rounded-full border border-white/10 px-2 py-0.5 text-[11px] uppercase tracking-[0.35em] text-white/60">
+                  <p className="text-sm font-semibold text-slate-900">{user.name}</p>
+                  <span className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] uppercase tracking-[0.35em] text-slate-500">
                     {user.role}
                   </span>
                 </div>
-                <p className="text-xs text-white/70">{user.focus}</p>
+                <p className="text-xs text-slate-600">{user.focus}</p>
               </div>
               <span className={`flex items-center gap-2 text-xs ${statusColor[user.status]}`}>
                 <Mic className="h-3.5 w-3.5" />

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -68,6 +68,11 @@
     @apply bg-white/5 border border-white/10 backdrop-blur-xl shadow-[0_20px_60px_rgba(0,0,0,0.35)] rounded-3xl;
   }
 
+  .light-panel {
+    @apply rounded-3xl border border-slate-200/70 bg-white/90 shadow-[0_18px_45px_rgba(15,23,42,0.12)] backdrop-blur-xl;
+    background-image: linear-gradient(135deg, rgba(226,240,254,0.95) 0%, rgba(255,255,255,0.92) 45%, rgba(234,249,243,0.95) 100%);
+  }
+
   .neon-border {
     box-shadow: 0 0 0 1px rgba(0, 244, 155, 0.35), 0 0 20px rgba(0, 244, 155, 0.35);
   }


### PR DESCRIPTION
## Summary
- add a reusable `light-panel` utility to support lighter dashboard surfaces
- refresh the collaboration panel styling for improved contrast on bright backgrounds
- update the AI spotlight card theme to match the lighter left column treatment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d79191eabc832ea46320c9c57842d4